### PR TITLE
Increase Contrast of active section in Table of Contents

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -26,10 +26,11 @@
 
 /* Appends padding to default color transition property */
 .table-of-contents__link {
-  transition: color var(--ifm-transition-fast) var(--ifm-transition-timing-default), padding var(--ifm-transition-fast) var(--ifm-transition-timing-default);
+  transition: color var(--ifm-transition-fast) var(--ifm-transition-timing-default), transform var(--ifm-transition-fast) var(--ifm-transition-timing-default);
+  display: block;
 }
 
 /* Adds padding to the current section */
 .table-of-contents__link--active {
-  padding-left: 0.5rem;
+  transform: translateX(5px);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,3 +23,13 @@
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
+
+/* Appends padding to default color transition property */
+.table-of-contents__link {
+  transition: color var(--ifm-transition-fast) var(--ifm-transition-timing-default), padding var(--ifm-transition-fast) var(--ifm-transition-timing-default);
+}
+
+/* Adds padding to the current section */
+.table-of-contents__link--active {
+  padding-left: 0.5rem;
+}


### PR DESCRIPTION
**Description:** Adds a simple translateX to the currently active section inside of the Docusaurus Table of Contents. Its a fairly minor change.

**Justification:** Currently, the Blurple color for the active sections (--ifm-color-primary / #7289da) doesn't have much of a contrast compared to the white background of the light theme. When changing sections, its sometimes not very obvious as to what section the user is currently in. Just changing the color to the darker variant didn't prove to be a good solution, as then we have the same problem in dark theme. The translateX just adds a bit more of a visual cue to the current section, while not drawing too much attention away from the current content of the page.

GIF Preview: 
![FFUunmccfK](https://user-images.githubusercontent.com/39167186/103036847-41d29a80-4530-11eb-9c73-308d67de206e.gif)
